### PR TITLE
Add an option to hide the project coverage

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -38,15 +38,6 @@
         }
       },
       {
-        "package": "Logger",
-        "repositoryURL": "https://github.com/shibapm/Logger",
-        "state": {
-          "branch": null,
-          "revision": "53c3ecca5abe8cf46697e33901ee774236d94cce",
-          "version": "0.2.3"
-        }
-      },
-      {
         "package": "Marathon",
         "repositoryURL": "https://github.com/JohnSundell/Marathon",
         "state": {
@@ -71,15 +62,6 @@
           "branch": null,
           "revision": "b63f2ec1b55f26c8e94159d81ad695aeb92f3d4e",
           "version": "0.9.0"
-        }
-      },
-      {
-        "package": "PackageConfig",
-        "repositoryURL": "https://github.com/shibapm/PackageConfig.git",
-        "state": {
-          "branch": null,
-          "revision": "877e49db48007239b8e184d9e90d3f12b79b3b16",
-          "version": "0.12.1"
         }
       },
       {
@@ -206,15 +188,6 @@
           "branch": null,
           "revision": "f43166a8e18fdd0857f29e303b1bb79a5428bca0",
           "version": "4.9.0"
-        }
-      },
-      {
-        "package": "Yams",
-        "repositoryURL": "https://github.com/jpsim/Yams.git",
-        "state": {
-          "branch": null,
-          "revision": "c947a306d2e80ecb2c0859047b35c73b8e1ca27f",
-          "version": "2.0.0"
         }
       }
     ]

--- a/Sources/DangerSwiftCoverage/DangerSwiftCoverage.swift
+++ b/Sources/DangerSwiftCoverage/DangerSwiftCoverage.swift
@@ -16,16 +16,16 @@ public enum Coverage {
         }
     }
 
-    public static func xcodeBuildCoverage(_ coveragePathType: CoveragePathType, minimumCoverage: Float, excludedTargets: [String] = []) {
-        xcodeBuildCoverage(coveragePathType, minimumCoverage: minimumCoverage, excludedTargets: excludedTargets, fileManager: .default, xcodeBuildCoverageParser: XcodeBuildCoverageParser.self, xcresultFinder: XcresultBundleFinder.self, danger: Danger())
+    public static func xcodeBuildCoverage(_ coveragePathType: CoveragePathType, minimumCoverage: Float, excludedTargets: [String] = [], hideProjectCoverage: Bool = false) {
+        xcodeBuildCoverage(coveragePathType, minimumCoverage: minimumCoverage, excludedTargets: excludedTargets, hideProjectCoverage: hideProjectCoverage, fileManager: .default, xcodeBuildCoverageParser: XcodeBuildCoverageParser.self, xcresultFinder: XcresultBundleFinder.self, danger: Danger())
     }
 
-    static func xcodeBuildCoverage(_ coveragePathType: CoveragePathType, minimumCoverage: Float, excludedTargets: [String], fileManager: FileManager, xcodeBuildCoverageParser: XcodeBuildCoverageParsing.Type, xcresultFinder: XcresultBundleFinding.Type, danger: DangerDSL) {
+    static func xcodeBuildCoverage(_ coveragePathType: CoveragePathType, minimumCoverage: Float, excludedTargets: [String], hideProjectCoverage: Bool = false, fileManager: FileManager, xcodeBuildCoverageParser: XcodeBuildCoverageParsing.Type, xcresultFinder: XcresultBundleFinding.Type, danger: DangerDSL) {
         let paths = modifiedFilesAbsolutePaths(fileManager: fileManager, danger: danger)
 
         do {
             let xcresultBundlePath = try coveragePathType.xcresultBundlePath(xcresultFinder: xcresultFinder, fileManager: fileManager)
-            let report = try xcodeBuildCoverageParser.coverage(xcresultBundlePath: xcresultBundlePath, files: paths, excludedTargets: excludedTargets)
+            let report = try xcodeBuildCoverageParser.coverage(xcresultBundlePath: xcresultBundlePath, files: paths, excludedTargets: excludedTargets, hideProjectCoverage: hideProjectCoverage)
             sendReport(report, minumumCoverage: minimumCoverage, danger: danger)
         } catch {
             danger.fail("Failed to get the coverage - Error: \(error.localizedDescription)")

--- a/Sources/DangerSwiftCoverage/XcodeBuild/XcodeBuildCoverageParser.swift
+++ b/Sources/DangerSwiftCoverage/XcodeBuild/XcodeBuildCoverageParser.swift
@@ -1,30 +1,30 @@
 import Foundation
 
 protocol XcodeBuildCoverageParsing {
-    static func coverage(xcresultBundlePath: String, files: [String], excludedTargets: [String]) throws -> Report
+    static func coverage(xcresultBundlePath: String, files: [String], excludedTargets: [String], hideProjectCoverage: Bool) throws -> Report
 }
 
 enum XcodeBuildCoverageParser: XcodeBuildCoverageParsing {
-    static func coverage(xcresultBundlePath: String, files: [String], excludedTargets: [String]) throws -> Report {
-        return try coverage(xcresultBundlePath: xcresultBundlePath, files: files, excludedTargets: excludedTargets, coverageFileFinder: XcodeCoverageFileFinder.self, xcCovParser: XcCovJSONParser.self)
+    static func coverage(xcresultBundlePath: String, files: [String], excludedTargets: [String], hideProjectCoverage: Bool) throws -> Report {
+        return try coverage(xcresultBundlePath: xcresultBundlePath, files: files, excludedTargets: excludedTargets, hideProjectCoverage: hideProjectCoverage, coverageFileFinder: XcodeCoverageFileFinder.self, xcCovParser: XcCovJSONParser.self)
     }
 
-    static func coverage(xcresultBundlePath: String, files: [String], excludedTargets: [String], coverageFileFinder: XcodeCoverageFileFinding.Type, xcCovParser: XcCovJSONParsing.Type) throws -> Report {
+    static func coverage(xcresultBundlePath: String, files: [String], excludedTargets: [String], hideProjectCoverage: Bool = false, coverageFileFinder: XcodeCoverageFileFinding.Type, xcCovParser: XcCovJSONParsing.Type) throws -> Report {
         if let coverageFile = coverageFileFinder.coverageFile(xcresultBundlePath: xcresultBundlePath) {
             let data = try xcCovParser.json(fromXCoverageFile: coverageFile)
-            return try report(fromJson: data, files: files, excludedTargets: excludedTargets)
+            return try report(fromJson: data, files: files, excludedTargets: excludedTargets, hideProjectCoverage: hideProjectCoverage)
         } else {
             let data = try xcCovParser.json(fromXcresultFile: xcresultBundlePath)
-            return try report(fromJson: data, files: files, excludedTargets: excludedTargets)
+            return try report(fromJson: data, files: files, excludedTargets: excludedTargets, hideProjectCoverage: hideProjectCoverage)
         }
     }
     
-    private static func report(fromJson data: Data, files: [String], excludedTargets: [String]) throws -> Report {
+    private static func report(fromJson data: Data, files: [String], excludedTargets: [String], hideProjectCoverage: Bool) throws -> Report {
         var coverage = try JSONDecoder().decode(XcodeBuildCoverage.self, from: data)
         coverage = coverage.filteringTargets(notOn: files, excludedTargets: excludedTargets)
 
         let targets = coverage.targets.map { ReportSection(fromTarget: $0) }
-        let messages = !targets.isEmpty ? ["Project coverage: \(coverage.percentageCoverage.description)%"] : []
+        let messages = !targets.isEmpty && !hideProjectCoverage ? ["Project coverage: \(coverage.percentageCoverage.description)%"] : []
 
         return Report(messages: messages, sections: targets)
     }

--- a/Tests/DangerSwiftCoverageTests/CoverageTests.swift
+++ b/Tests/DangerSwiftCoverageTests/CoverageTests.swift
@@ -201,7 +201,7 @@ private final class MockXcodeBuildCoverageParser: XcodeBuildCoverageParsing {
                                        ]),
                                    ])
 
-    static func coverage(xcresultBundlePath: String, files: [String], excludedTargets: [String]) throws -> Report {
+    static func coverage(xcresultBundlePath: String, files: [String], excludedTargets: [String], hideProjectCoverage hidesProjectCoverage: Bool) throws -> Report {
         receivedFiles = files
         receivedXcresultBundlePath = xcresultBundlePath
         receivedExcludedTargets = excludedTargets

--- a/Tests/DangerSwiftCoverageTests/XCTestManifests.swift
+++ b/Tests/DangerSwiftCoverageTests/XCTestManifests.swift
@@ -51,6 +51,7 @@ extension XcodeBuildCoverageParserTests {
         ("testItFiltersTheEmptyTargets", testItFiltersTheEmptyTargets),
         ("testItFiltersTheExcludedTarget", testItFiltersTheExcludedTarget),
         ("testItParsesTheJSONCorrectly", testItParsesTheJSONCorrectly),
+        ("testItHidesProjectCoverage", testItHidesProjectCoverage),
         ("testItReturnsTheCoverageWhenThereAreNoTargets", testItReturnsTheCoverageWhenThereAreNoTargets),
         ("testWhenThereIsNoXcoverageFileUsesXcresult", testWhenThereIsNoXcoverageFileUsesXcresult),
         ("testWhenXcoverageFileIsInvalidThrowsAnError", testWhenXcoverageFileIsInvalidThrowsAnError),

--- a/Tests/DangerSwiftCoverageTests/XcodeBuildCoverageParserTests.swift
+++ b/Tests/DangerSwiftCoverageTests/XcodeBuildCoverageParserTests.swift
@@ -45,6 +45,17 @@ final class XcodeBuildCoverageParserTests: XCTestCase {
         ])
     }
 
+    func testItHidesProjectCoverage() throws {
+        let files = ["/Users/franco/Projects/swift/Sources/Danger/BitBucketServerDSL.swift",
+                     "/Users/franco/Projects/swift/Sources/Danger/Danger.swift",
+                     "/Users/franco/Projects/swift/Sources/RunnerLib/Files Import/ImportsFinder.swift",
+                     "/Users/franco/Projects/swift/Sources/RunnerLib/HelpMessagePresenter.swift"]
+
+        let result = try XcodeBuildCoverageParser.coverage(xcresultBundlePath: "derived", files: files, excludedTargets: [], hideProjectCoverage: true, coverageFileFinder: FakeXcodeCoverageFileFinder.self, xcCovParser: MockedXcCovJSONParser.self)
+
+        XCTAssertTrue(result.messages.isEmpty)
+    }
+
     func testItFiltersTheExcludedTarget() throws {
         MockedXcCovJSONParser.xcoverageResult = XcCovXcTestJSONResponse.data(using: .utf8)
 


### PR DESCRIPTION
We're using the coverage report for multiple projects at once. This would result in duplicate coverage messages that are not really describing:

```
## Messages
Project coverage: 72.62%
-
Project coverage: 73.82%
```

On top of that, we're not really interested in that percentage and I can imagine that more users will have the same. Therefore, I decided to add a configuration to hide it completely 👌 

_Note: I couldn't find a Changelog so I didn't add that anywhere_