### PR TITLE
Implement regex-based target exclusion

### DIFF
--- a/Sources/DangerSwiftCoverage/DangerSwiftCoverage.swift
+++ b/Sources/DangerSwiftCoverage/DangerSwiftCoverage.swift
@@ -17,10 +17,15 @@ public enum Coverage {
     }
 
     public static func xcodeBuildCoverage(_ coveragePathType: CoveragePathType, minimumCoverage: Float, excludedTargets: [String] = [], hideProjectCoverage: Bool = false) {
+        let exactExcludedTargets = excludedTargets.map(ExcludedTarget.exact)
+        xcodeBuildCoverage(coveragePathType, minimumCoverage: minimumCoverage, excludedTargets: exactExcludedTargets, hideProjectCoverage: hideProjectCoverage, fileManager: .default, xcodeBuildCoverageParser: XcodeBuildCoverageParser.self, xcresultFinder: XcresultBundleFinder.self, danger: Danger())
+    }
+
+    public static func xcodeBuildCoverage(_ coveragePathType: CoveragePathType, minimumCoverage: Float, excludedTargets: [ExcludedTarget] = [], hideProjectCoverage: Bool = false) {
         xcodeBuildCoverage(coveragePathType, minimumCoverage: minimumCoverage, excludedTargets: excludedTargets, hideProjectCoverage: hideProjectCoverage, fileManager: .default, xcodeBuildCoverageParser: XcodeBuildCoverageParser.self, xcresultFinder: XcresultBundleFinder.self, danger: Danger())
     }
 
-    static func xcodeBuildCoverage(_ coveragePathType: CoveragePathType, minimumCoverage: Float, excludedTargets: [String], hideProjectCoverage: Bool = false, fileManager: FileManager, xcodeBuildCoverageParser: XcodeBuildCoverageParsing.Type, xcresultFinder: XcresultBundleFinding.Type, danger: DangerDSL) {
+    static func xcodeBuildCoverage(_ coveragePathType: CoveragePathType, minimumCoverage: Float, excludedTargets: [ExcludedTarget], hideProjectCoverage: Bool = false, fileManager: FileManager, xcodeBuildCoverageParser: XcodeBuildCoverageParsing.Type, xcresultFinder: XcresultBundleFinding.Type, danger: DangerDSL) {
         let paths = modifiedFilesAbsolutePaths(fileManager: fileManager, danger: danger)
 
         do {

--- a/Sources/DangerSwiftCoverage/Models/ExcludedTarget.swift
+++ b/Sources/DangerSwiftCoverage/Models/ExcludedTarget.swift
@@ -1,0 +1,13 @@
+public enum ExcludedTarget: Equatable {
+    case exact(String)
+    case regex(String)
+
+    func matches(string: String) -> Bool {
+        switch self {
+        case let .exact(needle):
+            return string == needle
+        case let .regex(regex):
+            return string.range(of: regex, options: .regularExpression) != nil
+        }
+    }
+}

--- a/Sources/DangerSwiftCoverage/Models/XcodeBuildCoverage.swift
+++ b/Sources/DangerSwiftCoverage/Models/XcodeBuildCoverage.swift
@@ -6,8 +6,14 @@ struct XcodeBuildCoverage: Decodable, PercentageCoverage {
     let lineCoverage: Float
     let targets: [Target]
 
-    func filteringTargets(notOn files: [String], excludedTargets: [String]) -> XcodeBuildCoverage {
-        let targets = self.targets.map { $0.filteringFiles(notOn: files) }.filter { !$0.files.isEmpty && !excludedTargets.contains($0.name) }
+    func filteringTargets(notOn files: [String], excludedTargets: [ExcludedTarget]) -> XcodeBuildCoverage {
+        let targets = self.targets
+            .map { $0.filteringFiles(notOn: files) }
+            .filter { target in
+                !target.files.isEmpty && !excludedTargets.contains {
+                    $0.matches(string: target.name)
+                }
+            }
         return XcodeBuildCoverage(coveredLines: coveredLines, executableLines: executableLines, lineCoverage: lineCoverage, targets: targets)
     }
 }

--- a/Sources/DangerSwiftCoverage/XcodeBuild/XcodeBuildCoverageParser.swift
+++ b/Sources/DangerSwiftCoverage/XcodeBuild/XcodeBuildCoverageParser.swift
@@ -1,20 +1,20 @@
 import Foundation
 
 protocol XcodeBuildCoverageParsing {
-    static func coverage(xcresultBundlePath: String, files: [String], excludedTargets: [String], hideProjectCoverage: Bool) throws -> Report
+    static func coverage(xcresultBundlePath: String, files: [String], excludedTargets: [ExcludedTarget], hideProjectCoverage: Bool) throws -> Report
 }
 
 enum XcodeBuildCoverageParser: XcodeBuildCoverageParsing {
-    static func coverage(xcresultBundlePath: String, files: [String], excludedTargets: [String], hideProjectCoverage: Bool) throws -> Report {
+    static func coverage(xcresultBundlePath: String, files: [String], excludedTargets: [ExcludedTarget], hideProjectCoverage: Bool) throws -> Report {
         try coverage(xcresultBundlePath: xcresultBundlePath, files: files, excludedTargets: excludedTargets, hideProjectCoverage: hideProjectCoverage, xcCovParser: XcCovJSONParser.self)
     }
 
-    static func coverage(xcresultBundlePath: String, files: [String], excludedTargets: [String], hideProjectCoverage: Bool = false, xcCovParser: XcCovJSONParsing.Type) throws -> Report {
+    static func coverage(xcresultBundlePath: String, files: [String], excludedTargets: [ExcludedTarget], hideProjectCoverage: Bool = false, xcCovParser: XcCovJSONParsing.Type) throws -> Report {
         let data = try xcCovParser.json(fromXcresultFile: xcresultBundlePath)
         return try report(fromJson: data, files: files, excludedTargets: excludedTargets, hideProjectCoverage: hideProjectCoverage)
     }
 
-    private static func report(fromJson data: Data, files: [String], excludedTargets: [String], hideProjectCoverage: Bool) throws -> Report {
+    private static func report(fromJson data: Data, files: [String], excludedTargets: [ExcludedTarget], hideProjectCoverage: Bool) throws -> Report {
         var coverage = try JSONDecoder().decode(XcodeBuildCoverage.self, from: data)
         coverage = coverage.filteringTargets(notOn: files, excludedTargets: excludedTargets)
 

--- a/Tests/DangerSwiftCoverageTests/CoverageTests.swift
+++ b/Tests/DangerSwiftCoverageTests/CoverageTests.swift
@@ -40,12 +40,12 @@ final class CoverageTests: XCTestCase {
         dsl = githubWithFilesDSL(created: created, modified: modified)
 
         let currentPathProvider = StubbedFileManager()
-        let excluedTargets = ["TargetA.framework", "TargetB.framework"]
+        let excludedTargets: [ExcludedTarget] = [.exact("TargetA.framework"), .exact("TargetB.framework")]
 
-        Coverage.xcodeBuildCoverage(.derivedDataFolder("derived"), minimumCoverage: 50, excludedTargets: excluedTargets, fileManager: currentPathProvider, xcodeBuildCoverageParser: MockXcodeBuildCoverageParser.self, xcresultFinder: FakeXcodeResultBundleFinder.self, danger: dsl)
+        Coverage.xcodeBuildCoverage(.derivedDataFolder("derived"), minimumCoverage: 50, excludedTargets: excludedTargets, fileManager: currentPathProvider, xcodeBuildCoverageParser: MockXcodeBuildCoverageParser.self, xcresultFinder: FakeXcodeResultBundleFinder.self, danger: dsl)
 
         XCTAssertEqual(MockXcodeBuildCoverageParser.receivedXcresultBundlePath, FakeXcodeResultBundleFinder.result)
-        XCTAssertEqual(MockXcodeBuildCoverageParser.receivedExcludedTargets, excluedTargets)
+        XCTAssertEqual(MockXcodeBuildCoverageParser.receivedExcludedTargets, excludedTargets)
         XCTAssertEqual(MockXcodeBuildCoverageParser.receivedFiles, (created + modified).map { currentPathProvider.fakePath + "/" + $0 })
     }
 
@@ -53,12 +53,12 @@ final class CoverageTests: XCTestCase {
         dsl = githubWithFilesDSL(created: created, modified: modified)
 
         let currentPathProvider = StubbedFileManager()
-        let excluedTargets = ["TargetA.framework", "TargetB.framework"]
+        let excludedTargets: [ExcludedTarget] = [.exact("TargetA.framework"), .exact("TargetB.framework")]
 
-        Coverage.xcodeBuildCoverage(.xcresultBundle("custom"), minimumCoverage: 50, excludedTargets: excluedTargets, fileManager: currentPathProvider, xcodeBuildCoverageParser: MockXcodeBuildCoverageParser.self, xcresultFinder: FakeXcodeResultBundleFinder.self, danger: dsl)
+        Coverage.xcodeBuildCoverage(.xcresultBundle("custom"), minimumCoverage: 50, excludedTargets: excludedTargets, fileManager: currentPathProvider, xcodeBuildCoverageParser: MockXcodeBuildCoverageParser.self, xcresultFinder: FakeXcodeResultBundleFinder.self, danger: dsl)
 
         XCTAssertEqual(MockXcodeBuildCoverageParser.receivedXcresultBundlePath, "custom")
-        XCTAssertEqual(MockXcodeBuildCoverageParser.receivedExcludedTargets, excluedTargets)
+        XCTAssertEqual(MockXcodeBuildCoverageParser.receivedExcludedTargets, excludedTargets)
         XCTAssertEqual(MockXcodeBuildCoverageParser.receivedFiles, (created + modified).map { currentPathProvider.fakePath + "/" + $0 })
     }
 
@@ -176,7 +176,7 @@ private final class FakeXcodeResultBundleFinder: XcresultBundleFinding {
 private final class MockXcodeBuildCoverageParser: XcodeBuildCoverageParsing {
     static var receivedFiles: [String]!
     static var receivedXcresultBundlePath: String!
-    static var receivedExcludedTargets: [String]!
+    static var receivedExcludedTargets: [ExcludedTarget]!
 
     static var shouldSucceed = false
 
@@ -201,7 +201,7 @@ private final class MockXcodeBuildCoverageParser: XcodeBuildCoverageParsing {
                                        ]),
                                    ])
 
-    static func coverage(xcresultBundlePath: String, files: [String], excludedTargets: [String], hideProjectCoverage _: Bool) throws -> Report {
+    static func coverage(xcresultBundlePath: String, files: [String], excludedTargets: [ExcludedTarget], hideProjectCoverage _: Bool) throws -> Report {
         receivedFiles = files
         receivedXcresultBundlePath = xcresultBundlePath
         receivedExcludedTargets = excludedTargets

--- a/Tests/DangerSwiftCoverageTests/XcodeBuildCoverageParserTests.swift
+++ b/Tests/DangerSwiftCoverageTests/XcodeBuildCoverageParserTests.swift
@@ -30,7 +30,27 @@ final class XcodeBuildCoverageParserTests: XCTestCase {
                      "/Users/franco/Projects/swift/Sources/RunnerLib/Files Import/ImportsFinder.swift",
                      "/Users/franco/Projects/swift/Sources/RunnerLib/HelpMessagePresenter.swift"]
 
-        let result = try XcodeBuildCoverageParser.coverage(xcresultBundlePath: "derived", files: files, excludedTargets: ["RunnerLib.xctest"], xcCovParser: MockedXcCovJSONParser.self)
+        let result = try XcodeBuildCoverageParser.coverage(xcresultBundlePath: "derived", files: files, excludedTargets: [.exact("RunnerLib.xctest")], xcCovParser: MockedXcCovJSONParser.self)
+
+        XCTAssertEqual(result.messages, ["Project coverage: 50.09%"])
+
+        let firstSection = result.sections[0]
+        XCTAssertEqual(firstSection.titleText, "Danger.framework: Coverage: 43.44")
+        XCTAssertEqual(firstSection.items, [
+            ReportFile(fileName: "BitBucketServerDSL.swift", coverage: 100),
+            ReportFile(fileName: "Danger.swift", coverage: 0),
+        ])
+
+        XCTAssertEqual(result.sections.count, 1)
+    }
+
+    func testItFiltersTheExcludedTargetByRegexp() throws {
+        let files = ["/Users/franco/Projects/swift/Sources/Danger/BitBucketServerDSL.swift",
+                     "/Users/franco/Projects/swift/Sources/Danger/Danger.swift",
+                     "/Users/franco/Projects/swift/Sources/RunnerLib/Files Import/ImportsFinder.swift",
+                     "/Users/franco/Projects/swift/Sources/RunnerLib/HelpMessagePresenter.swift"]
+
+        let result = try XcodeBuildCoverageParser.coverage(xcresultBundlePath: "derived", files: files, excludedTargets: [.regex("\\.xctest$")], xcCovParser: MockedXcCovJSONParser.self)
 
         XCTAssertEqual(result.messages, ["Project coverage: 50.09%"])
 


### PR DESCRIPTION
Hey, first of all, thanks for this plugin.

Sometimes it's not feasible to explicitly list targets one would like to exlude, that's why I implemented this regular expression exclusion support alongside the existing exact match behavior.

Note: I'm getting `Package.resolved` changes while building, not sure if I should include them in the PR or not 🤔 